### PR TITLE
Display profile in job runs

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -67,6 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         region: ${{ fromJson(inputs.regions) }}
+        profile: [ "${{ inputs.profile }}" ]
     outputs:
       tag: ${{ steps.meta.outputs.tags }}
     steps:


### PR DESCRIPTION
When multiple publishes kick off, it's not evident what profile it's using without viewing the logs.
