### PR TITLE
Check if repo exists before publishing

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -100,10 +100,24 @@ jobs:
           tags: |
             type=sha,enable=true,prefix=,format=short
 
+        # Publish expects the repo to already exist,
+        # but in the initial bootstrap, it won't yet exist,
+        # so exit gracefully
+      - name: Check if repo exists
+        id: check-repo
+        run: |
+          existing_repo=$(aws ecr describe-repositories --query "repositories[?repositoryName=='${{ inputs.ecr_repository }}'].repositoryName" --output text)
+          if [ -n "${existing_repo}" ]; then
+            echo "::set-output name=exists::true"
+          else
+            echo "::set-output name=exists::false"
+          fi
+
         # This step is useful if the workflow is re-run,
         # and the repository has IMMUTABILITY enabled
       - name: Check if tag has already been published
         id: check-tag
+        if: steps.check-repo.outputs.exists == 'true'
         run: |
           gitsha=$(git rev-parse --short HEAD)
           existing_tag=$(aws ecr list-images --repository-name "${{ inputs.ecr_repository }}" --query "imageIds[?imageTag=='$gitsha'].imageTag" --output text)
@@ -114,7 +128,7 @@ jobs:
           fi
 
       - name: Login to ghcr.io
-        if: ${{ inputs.login_to_ghcr }} && steps.check-tag.outputs.exists == 'false'
+        if: ${{ inputs.login_to_ghcr }} && steps.check-tag.outputs.exists == 'false && steps.check-repo.outputs.exists == 'true'
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -123,11 +137,11 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-        if: steps.check-tag.outputs.exists == 'false'
+        if: steps.check-tag.outputs.exists == 'false' && steps.check-repo.outputs.exists == 'true'
 
       - name: Cache Docker layers
         uses: actions/cache@v2
-        if: steps.check-tag.outputs.exists == 'false'
+        if: steps.check-tag.outputs.exists == 'false' && steps.check-repo.outputs.exists == 'true'
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -136,7 +150,7 @@ jobs:
 
       - name: Build and push to ECR
         uses: docker/build-push-action@v2
-        if: steps.check-tag.outputs.exists == 'false'
+        if: steps.check-tag.outputs.exists == 'false' && steps.check-repo.outputs.exists == 'true'
         with:
           # All layers should be cached to optimize for multi-environment deploys
           # Can't cache locally. Blocked by https://github.com/docker/build-push-action/issues/252


### PR DESCRIPTION
This fixes the initial bootstrapping issue where an image won't publish
because the repo does not yet exist